### PR TITLE
Downgrade JetBrains.Annotations package to 2019.1.3 to retain compatibility

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,7 +38,7 @@ Using guardians and following the Fail Fast principle, you can easily find and f
 Check out the source code for more information: https://github.com/FlabIt/guardians</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.91">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,7 +5,6 @@
 ### Features
 
 * Adding description for NuGet package
-* Updated JetBrains.Annotations package to 2020.1.0
 * Improved exception code documentation
 * Improved and added more tests
 * Adding default value for argument names for Enumerable Guardians


### PR DESCRIPTION
This dependency will be removed soon.