### PR TITLE
Automatic update of Nerdbank.GitVersioning to 3.2.31

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,7 +39,7 @@ Check out the source code for more information: https://github.com/FlabIt/guardi
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.91">
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.2.31">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/_git2_a05728
+++ b/_git2_a05728
@@ -1,0 +1,1 @@
+testing


### PR DESCRIPTION
NuKeeper has generated a minor update of `Nerdbank.GitVersioning` to `3.2.31` from `3.1.91`
`Nerdbank.GitVersioning 3.2.31` was published at `2020-07-23T15:57:35Z`, 12 days ago

1 project update:
Updated `Directory.Build.props` to `Nerdbank.GitVersioning` `3.2.31` from `3.1.91`

[Nerdbank.GitVersioning 3.2.31 on NuGet.org](https://www.nuget.org/packages/Nerdbank.GitVersioning/3.2.31)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
