### PR TITLE
Automatic update of 3 packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/_git2_a02512
+++ b/_git2_a02512
@@ -1,0 +1,1 @@
+testing

--- a/tests/FlabIt.Guardians.Tests/FlabIt.Guardians.Tests.csproj
+++ b/tests/FlabIt.Guardians.Tests/FlabIt.Guardians.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeCoverage" Version="16.6.1" />
+    <PackageReference Include="Microsoft.CodeCoverage" Version="16.7.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
3 packages were updated in 2 projects:
`Microsoft.CodeQuality.Analyzers`, `Microsoft.CodeAnalysis.FxCopAnalyzers`, `Microsoft.CodeCoverage`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `Microsoft.CodeQuality.Analyzers` to `3.3.0` from `3.0.0`
`Microsoft.CodeQuality.Analyzers 3.3.0` was published at `2020-08-10T19:51:47Z`, 8 days ago

1 project update:
Updated `Directory.Build.props` to `Microsoft.CodeQuality.Analyzers` `3.3.0` from `3.0.0`

[Microsoft.CodeQuality.Analyzers 3.3.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.CodeQuality.Analyzers/3.3.0)

NuKeeper has generated a minor update of `Microsoft.CodeAnalysis.FxCopAnalyzers` to `3.3.0` from `3.0.0`
`Microsoft.CodeAnalysis.FxCopAnalyzers 3.3.0` was published at `2020-08-10T19:51:45Z`, 8 days ago

1 project update:
Updated `Directory.Build.props` to `Microsoft.CodeAnalysis.FxCopAnalyzers` `3.3.0` from `3.0.0`

[Microsoft.CodeAnalysis.FxCopAnalyzers 3.3.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers/3.3.0)

NuKeeper has generated a minor update of `Microsoft.CodeCoverage` to `16.7.0` from `16.6.1`
`Microsoft.CodeCoverage 16.7.0` was published at `2020-08-06T12:13:39Z`, 12 days ago

1 project update:
Updated `tests\FlabIt.Guardians.Tests\FlabIt.Guardians.Tests.csproj` to `Microsoft.CodeCoverage` `16.7.0` from `16.6.1`

[Microsoft.CodeCoverage 16.7.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.CodeCoverage/16.7.0)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
