### PR TITLE
Automatic update of 2 packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/_git2_a01552
+++ b/_git2_a01552
@@ -1,0 +1,1 @@
+testing


### PR DESCRIPTION
2 packages were updated in 1 project:
`Microsoft.CodeQuality.Analyzers`, `Microsoft.CodeAnalysis.FxCopAnalyzers`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `Microsoft.CodeQuality.Analyzers` to `3.3.0` from `3.0.0`
`Microsoft.CodeQuality.Analyzers 3.3.0` was published at `2020-08-10T19:51:47Z`, 15 days ago

1 project update:
Updated `Directory.Build.props` to `Microsoft.CodeQuality.Analyzers` `3.3.0` from `3.0.0`

[Microsoft.CodeQuality.Analyzers 3.3.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.CodeQuality.Analyzers/3.3.0)

NuKeeper has generated a minor update of `Microsoft.CodeAnalysis.FxCopAnalyzers` to `3.3.0` from `3.0.0`
`Microsoft.CodeAnalysis.FxCopAnalyzers 3.3.0` was published at `2020-08-10T19:51:45Z`, 15 days ago

1 project update:
Updated `Directory.Build.props` to `Microsoft.CodeAnalysis.FxCopAnalyzers` `3.3.0` from `3.0.0`

[Microsoft.CodeAnalysis.FxCopAnalyzers 3.3.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers/3.3.0)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
